### PR TITLE
Væk med grimt mellemrum

### DIFF
--- a/signup/templates/signup/main.html
+++ b/signup/templates/signup/main.html
@@ -98,9 +98,7 @@
       <h2>Kontakt</h2>
       <p>
         Hvis du har nogen spørgsmål, kan du kontakte Bitbureauet pr. mail på
-        <a href="mailto:bitbureauet@bitbureauet.dk">
-          bitbureauet@bitbureauet.dk
-        </a>.
+        <a href="mailto:bitbureauet@bitbureauet.dk">bitbureauet@bitbureauet.dk</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
I det mindste i _min_ browser blev der, pga. whitespace, renderet et grimt mellemrum mellem e-mailadressen og det efterfølgende punktum.
