### PR TITLE
Add CSP HTTP header

### DIFF
--- a/ansible/roles/cryptoparty/templates/nginx_site.j2
+++ b/ansible/roles/cryptoparty/templates/nginx_site.j2
@@ -37,6 +37,7 @@ server {
     resolver_timeout 10s;
 
     add_header Strict-Transport-Security 'max-age=31536000; includeSubdomains; preload';
+    add_header Content-Security-Policy "default-src 'self'";
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
 


### PR DESCRIPTION
Activating Content Security Policy mitigates many forms of XSS; this is particularly useful on a site which relies heavily on user submitted content. This particular setting says that only resources (images, styles, scripts, etc.) from cryptoparty.dk should be rendered by the UA.

A different, stricter, option would be set the header to something like 

```
default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';
```

which says that scripts, XHR, images, and CSS from cryptoparty.dk is cool, but everything else should be blocked.
